### PR TITLE
COCOA動作チェッカー更新終了にともなう連絡先の変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ COCOA(Covid-19 Exposure Notification System in Japan) Signal Checker
 
 - COCOAの普及を支援するために、端末からCOCOAの接触確認をする信号が発信されているか確認するためのツールです
 - [2020年11月より開発に取り組んでおり](https://dena.com/jp/article/003672)、[2021年1月に一般提供を開始](https://dena.com/jp/article/003673)しました。
+- Github pagesを用いた特設ページを継続するため、archived projectには変更しておりませんが、2021年12月に会社としてのメンテナンス・更新を終了しました。
 
 ## COCOA動作チェッカーとは
 
@@ -18,7 +19,7 @@ COCOA(Covid-19 Exposure Notification System in Japan) Signal Checker
 ## cocoa-checkerへの質問・要望・提案等について
 - プログラム自体に対する改善提案は、githubレポジトリへの pull-request や、 issue を通じてお寄せくださいますようお願いいたします。
   - ただし、ツールの性質上、大きな機能拡張は行わない予定であることから、お寄せいただいた pull-request や issue に対して、ご回答できかねる場合がありますことをご了承ください。
-- 利用方法に関するご質問や、その他のご質問・ご要望については、COCOA動作チェッカー事務局(cocoa-checker@dena.com)までご連絡いただきますようお願いいたします。
+- 利用方法に関するご質問や、その他のご質問・ご要望についても、会社としてのメンテナンス・更新を終了していることから、githubレポジトリへのissue提出でご連絡いただきますようお願いいたします。
 
 ## LICENSE
 

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
       </div>
     </div>
     <div class="footer">
-      <a href="mailto:cocoa-checker@dena.com?subject=【COCOA動作チェッカー】ウェブサイトに関するお問い合わせ">お問い合わせ</a>　　<a onclick="notice_window_toggle('operator')">ご利用にあたって</a><br />
+      <a href="https://github.com/DeNA/cocoa-checker">お問い合わせ</a>　　<a onclick="notice_window_toggle('operator')">ご利用にあたって</a><br />
       Copyright &copy; DeNA Co., Ltd. All rights reserved.
     </div>
   </article>
@@ -63,7 +63,7 @@
       </div>
     </div>
     <div class="footer">
-      <a href="mailto:cocoa-checker@dena.com?subject=【COCOA動作チェッカー】ウェブサイトに関するお問い合わせ">お問い合わせ</a>　　<a onclick="notice_window_toggle('operator')">ご利用にあたって</a><br />
+      <a href="https://github.com/DeNA/cocoa-checker">お問い合わせ</a>　　<a onclick="notice_window_toggle('operator')">ご利用にあたって</a><br />
       Copyright &copy; DeNA Co., Ltd. All rights reserved.
     </div>
   </article>
@@ -216,7 +216,7 @@
       </div>
     </div>
     <div class="footer">
-      <a href="mailto:cocoa-checker@dena.com?subject=【COCOA動作チェッカー】ウェブサイトに関するお問い合わせ">お問い合わせ</a>　　<a onclick="notice_window_toggle('operator')">ご利用にあたって</a><br />
+      <a href="https://github.com/DeNA/cocoa-checker">お問い合わせ</a>　　<a onclick="notice_window_toggle('operator')">ご利用にあたって</a><br />
       Copyright &copy; DeNA Co., Ltd. All rights reserved.
     </div>
   </article>
@@ -241,7 +241,7 @@
       <div style="height: 80px"></div>
     </div>
     <div class="footer">
-      <a href="mailto:cocoa-checker@dena.com?subject=【COCOA動作チェッカー】ウェブサイトに関するお問い合わせ">お問い合わせ</a>　　ご利用にあたって<br />
+      <a href="https://github.com/DeNA/cocoa-checker">お問い合わせ</a>　　ご利用にあたって<br />
       Copyright &copy; DeNA Co., Ltd. All rights reserved.
     </div>
   </article>
@@ -305,7 +305,7 @@
       </div>
     </div>
     <div class="footer">
-      <a href="mailto:cocoa-checker@dena.com?subject=【COCOA動作チェッカー】ウェブサイトに関するお問い合わせ">お問い合わせ</a>　　<a onclick="notice_window_toggle('enduser')">ご利用にあたって</a><br />
+      <a href="https://github.com/DeNA/cocoa-checker">お問い合わせ</a>　　<a onclick="notice_window_toggle('enduser')">ご利用にあたって</a><br />
       Copyright &copy; DeNA Co., Ltd. All rights reserved.
     </div>
   </article>
@@ -349,7 +349,7 @@
       <div style="height: 20px"></div>
     </div>
     <div class="footer">
-      <a href="mailto:cocoa-checker@dena.com?subject=【COCOA動作チェッカー】ウェブサイトに関するお問い合わせ">お問い合わせ</a>　　ご利用にあたって<br />
+      <a href="https://github.com/DeNA/cocoa-checker">お問い合わせ</a>　　ご利用にあたって<br />
       Copyright &copy; DeNA Co., Ltd. All rights reserved.
     </div>
   </article>
@@ -377,7 +377,7 @@
       </div>
     </div>
     <div class="footer">
-      <a href="mailto:cocoa-checker@dena.com?subject=【COCOA動作チェッカー】ウェブサイトに関するお問い合わせ">お問い合わせ</a>　　<a onclick="notice_window_toggle('starting_detection')">ご利用にあたって</a><br />
+      <a href="https://github.com/DeNA/cocoa-checker">お問い合わせ</a>　　<a onclick="notice_window_toggle('starting_detection')">ご利用にあたって</a><br />
       Copyright &copy; DeNA Co., Ltd. All rights reserved.
     </div>
   </article>
@@ -424,7 +424,7 @@
       </div>
     </div>
     <div class="footer">
-      <a href="mailto:cocoa-checker@dena.com?subject=【COCOA動作チェッカー】ウェブサイトに関するお問い合わせ">お問い合わせ</a>　　<a onclick="notice_window_toggle('detect_succeed')">ご利用にあたって</a><br />
+      <a href="https://github.com/DeNA/cocoa-checker">お問い合わせ</a>　　<a onclick="notice_window_toggle('detect_succeed')">ご利用にあたって</a><br />
       Copyright &copy; DeNA Co., Ltd. All rights reserved.
     </div>
   </article>
@@ -481,7 +481,7 @@
       </div>
     </div>
     <div class="footer">
-      <a href="mailto:cocoa-checker@dena.com?subject=【COCOA動作チェッカー】ウェブサイトに関するお問い合わせ">お問い合わせ</a>　　<a onclick="notice_window_toggle('detect_failed')">ご利用にあたって</a><br />
+      <a href="https://github.com/DeNA/cocoa-checker">お問い合わせ</a>　　<a onclick="notice_window_toggle('detect_failed')">ご利用にあたって</a><br />
       Copyright &copy; DeNA Co., Ltd. All rights reserved.
     </div>
   </article>
@@ -550,7 +550,7 @@
       </div>
       <div style="height: 8px"></div>
       <div class="text_16px_150p" style="text-align: left;">
-        メールで <a href="mailto:cocoa-checker@dena.com?subject=【COCOA動作チェッカー】ウェブサイトに関するお問い合わせ">cocoa-checker@dena.com</a> 宛てにお問い合わせください。対応時間は平日10時～18時となります。
+        会社としてのメンテナンスを終了しているため、Github <a href="https://github.com/DeNA/cocoa-checker">https://github.com/DeNA/cocoa-checker</a> のissue機能などをご活用ください。
       </div>
       <div style="height: 32px"></div>
 
@@ -568,7 +568,7 @@
       <div class="touch_button_inner">もどる</div>
     </div>
     <div class="footer">
-      <a href="mailto:cocoa-checker@dena.com?subject=【COCOA動作チェッカー】ウェブサイトに関するお問い合わせ">お問い合わせ</a>　　<a onclick="notice_window_toggle('faq_operator')">ご利用にあたって</a><br />
+      <a href="https://github.com/DeNA/cocoa-checker">お問い合わせ</a>　　<a onclick="notice_window_toggle('faq_operator')">ご利用にあたって</a><br />
       Copyright &copy; DeNA Co., Ltd. All rights reserved.
     </div>
   </article>
@@ -673,7 +673,7 @@
       </div>
       <div style="height: 8px"></div>
       <div class="text_16px_150p" style="text-align: left;">
-        メールで <a href="mailto:cocoa-checker@dena.com?subject=【COCOA動作チェッカー】ウェブサイトに関するお問い合わせ">cocoa-checker@dena.com</a> 宛てにお問い合わせください。対応時間は平日10時～18時となります。
+        会社としてのメンテナンスを終了しているため、Github <a href="https://github.com/DeNA/cocoa-checker">https://github.com/DeNA/cocoa-checker</a> のissue機能などをご活用ください。
       </div>
       <div style="height: 32px"></div>
 
@@ -683,7 +683,7 @@
       <div class="touch_button_inner">もどる</div>
     </div>
     <div class="footer">
-      <a href="mailto:cocoa-checker@dena.com?subject=【COCOA動作チェッカー】ウェブサイトに関するお問い合わせ">お問い合わせ</a>　　<a onclick="notice_window_toggle('faq_enduser')">ご利用にあたって</a><br />
+      <a href="https://github.com/DeNA/cocoa-checker">お問い合わせ</a>　　<a onclick="notice_window_toggle('faq_enduser')">ご利用にあたって</a><br />
       Copyright &copy; DeNA Co., Ltd. All rights reserved.
     </div>
   </article>
@@ -764,12 +764,9 @@
       </div>
       <div style="height: 8px"></div>
       <div class="text_16px_150p" style="text-align: left;">
-        当サイトについてのお問い合わせは下記にお願いいたします。お問い合わせにあたっては、6.プライバシーポリシーもご確認ください。<br />
+        当サイトについてのお問い合わせはGithubレポジトリ宛にお願いいたします。レポジトリ上での質問・相談はgithubレポジトリ上で公開された状態になることに留意下さい。<br />
         <br />
-        COCOA動作チェッカー事務局<br />
-        <a href="mailto:cocoa-checker@dena.com?subject=【COCOA動作チェッカー】ウェブサイトに関するお問い合わせ">cocoa-checker@dena.com</a><br />
-        <br />
-        ※お手数をお掛けしますが、件名に「【COCOA動作チェッカー】ウェブサイトに関するお問い合わせ」とご記載をお願いいたします。
+        <a href="https://github.com/DeNA/cocoa-checker">https://github.com/DeNA/cocoa-checker</a><br />
       </div>
       <div style="height: 32px"></div>
 
@@ -778,7 +775,7 @@
       </div>
       <div style="height: 8px"></div>
       <div class="text_16px_150p" style="text-align: left;">
-        当サイトでは、当サイトについてのお問い合わせをいただくときに限って、お問い合わせ対応の目的で、お問い合わせいただいた方の個人情報を収集・利用します。個人情報の収集・利用に関する当社のプライバシーポリシーは下記よりご確認いただけます。<br />
+        当サイトでは、当サイトについてのお問い合わせをいただくときに限って、お問い合わせ対応の目的で、お問い合わせいただいた方の個人情報を収集・利用していました。個人情報の収集・利用に関する当社のプライバシーポリシーは下記よりご確認いただけます。<br />
         <a href="https://dena.com/jp/privacy/" target="_blank" rel="noopener noreferrer">https://dena.com/jp/privacy/</a>
       </div>
       <div style="height: 32px"></div>
@@ -790,7 +787,7 @@
     </div>
     <div style="height: 20px"></div>
     <div class="footer">
-      <a href="mailto:cocoa-checker@dena.com?subject=【COCOA動作チェッカー】ウェブサイトに関するお問い合わせ">お問い合わせ</a>　　ご利用にあたって<br />
+      <a href="https://github.com/DeNA/cocoa-checker">お問い合わせ</a>　　ご利用にあたって<br />
       Copyright &copy; DeNA Co., Ltd. All rights reserved.
     </div>
   </article>


### PR DESCRIPTION
更新終了に伴って会社のお問い合わせ窓口が停止するので、メールアドレスの記載を削除する